### PR TITLE
Run tests in verbose mode

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -6,4 +6,4 @@ COPY . /go/src/github.com/danihodovic/contentful-terraform
 
 RUN go get
 
-CMD go test
+CMD go test -v

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ build:
 
 .PHONY: test
 test: build
-	docker run contentful-terraform-test go test
+	docker run \
+		contentful-terraform-test \
+		go test -v
 
 .PHONY: interactive
 interactive:
-	docker run -it -v $(shell pwd):/go/src/github.com/danihodovic/contentful-terraform contentful-terraform-test bash
+	docker run -it \
+		-v $(shell pwd):/go/src/github.com/danihodovic/contentful-terraform \
+		contentful-terraform-test \
+		bash


### PR DESCRIPTION
C & P from the terraform test source code:

// Tests will fail unless the verbose flag (`go test -v`, or explicitly
// the "-test.v" flag) is set. Because some acceptance tests take quite
// long, we require the verbose flag so users are able to see progress
// output.

The tests don't seem to fail, however it's not visible that the
terraform tests are skipped when -v is not used.