### PR TITLE
use new sdk usage, only store sdk client in provider config

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -37,23 +37,12 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	c, err := contentful.New(&contentful.Settings{
-		CMAToken: d.Get("cma_token").(string),
-		BaseURL:  "https://api.flinkly.com",
-	})
-	if err != nil {
-		return nil, err
-	}
+	cma := contentful.NewCMA(d.Get("cma_token").(string))
+	cma.SetOrganization(d.Get("organization_id").(string))
 
 	if os.Getenv("TF_LOG") != "" {
-		c.Debug = true
+		cma.Debug = true
 	}
 
-	config := map[string]interface{}{
-		"cma_token":       d.Get("cma_token").(string),
-		"organization_id": d.Get("organization_id").(string),
-		"client":          c,
-	}
-
-	return config, nil
+	return cma, nil
 }

--- a/resource_contentful_apikey.go
+++ b/resource_contentful_apikey.go
@@ -43,8 +43,7 @@ func resourceContentfulAPIKey() *schema.Resource {
 }
 
 func resourceCreateAPIKey(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -68,8 +67,7 @@ func resourceCreateAPIKey(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceUpdateAPIKey(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -97,8 +95,7 @@ func resourceUpdateAPIKey(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceReadAPIKey(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -115,8 +112,7 @@ func resourceReadAPIKey(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceDeleteAPIKey(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {

--- a/resource_contentful_contenttype.go
+++ b/resource_contentful_contenttype.go
@@ -80,8 +80,7 @@ func resourceContentfulContentType() *schema.Resource {
 }
 
 func resourceContentTypeCreate(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -123,9 +122,8 @@ func resourceContentTypeCreate(d *schema.ResourceData, m interface{}) (err error
 }
 
 func resourceContentTypeRead(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
 		return err
@@ -137,9 +135,8 @@ func resourceContentTypeRead(d *schema.ResourceData, m interface{}) (err error) 
 }
 
 func resourceContentTypeUpdate(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
 		return err
@@ -181,9 +178,8 @@ func resourceContentTypeUpdate(d *schema.ResourceData, m interface{}) (err error
 }
 
 func resourceContentTypeDelete(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
 		return err

--- a/resource_contentful_contenttype_test.go
+++ b/resource_contentful_contenttype_test.go
@@ -45,8 +45,7 @@ func testAccCheckContentfulContentTypeExists(n string, contentType *contentful.C
 			return fmt.Errorf("No space_id is set")
 		}
 
-		configMap := testAccProvider.Meta().(map[string]interface{})
-		client := configMap["client"].(*contentful.Contentful)
+		client := testAccProvider.Meta().(*contentful.Contentful)
 
 		space, err := client.GetSpace(spaceID)
 		if err != nil {
@@ -65,7 +64,6 @@ func testAccCheckContentfulContentTypeExists(n string, contentType *contentful.C
 }
 
 func testAccCheckContentfulContentTypeDestroy(s *terraform.State) (err error) {
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "contentful_contenttype" {
 			continue
@@ -76,8 +74,7 @@ func testAccCheckContentfulContentTypeDestroy(s *terraform.State) (err error) {
 			return fmt.Errorf("No space_id is set")
 		}
 
-		configMap := testAccProvider.Meta().(map[string]interface{})
-		client := configMap["client"].(*contentful.Contentful)
+		client := testAccProvider.Meta().(*contentful.Contentful)
 
 		space, err := client.GetSpace(spaceID)
 
@@ -110,7 +107,7 @@ resource "contentful_contenttype" "mycontenttype" {
 
   name = "Terraform"
   description = "Terraform Content Type"
-  displayField = "field1"
+  display_field = "field1"
 
   field {
     id = "field1"
@@ -125,7 +122,6 @@ resource "contentful_contenttype" "mycontenttype" {
     type = "Number"
     required = false
   }
-
 }
 `
 
@@ -140,7 +136,7 @@ resource "contentful_contenttype" "mycontenttype" {
 
   name = "Terraform name change"
   description = "Terraform Content Type"
-  displayField = "field1"
+  display_field = "field1"
 
   field {
     id = "field1"

--- a/resource_contentful_locale.go
+++ b/resource_contentful_locale.go
@@ -49,8 +49,7 @@ func resourceContentfulLocale() *schema.Resource {
 }
 
 func resourceCreateLocale(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -79,8 +78,7 @@ func resourceCreateLocale(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceReadLocale(d *schema.ResourceData, m interface{}) error {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -101,8 +99,7 @@ func resourceReadLocale(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceUpdateLocale(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -132,8 +129,7 @@ func resourceUpdateLocale(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceDeleteLocale(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {

--- a/resource_contentful_space.go
+++ b/resource_contentful_space.go
@@ -36,10 +36,9 @@ func resourceContentfulSpace() *schema.Resource {
 }
 
 func resourceSpaceCreate(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
-	space := client.NewSpace(configMap["organization_id"].(string))
+	space := client.NewSpace()
 	space.Name = d.Get("name").(string)
 	space.DefaultLocale = d.Get("default_locale").(string)
 	err = space.Save()
@@ -58,9 +57,8 @@ func resourceSpaceCreate(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceSpaceRead(d *schema.ResourceData, m interface{}) error {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	_, err := client.GetSpace(d.Id())
 
 	if _, ok := err.(contentful.NotFoundError); ok {
@@ -72,9 +70,8 @@ func resourceSpaceRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSpaceUpdate(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	space, err := client.GetSpace(d.Id())
 	if err != nil {
 		return err
@@ -90,9 +87,8 @@ func resourceSpaceUpdate(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceSpaceDelete(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
+	client := m.(*contentful.Contentful)
 
-	client := configMap["client"].(*contentful.Contentful)
 	space, err := client.GetSpace(d.Id())
 	if err != nil {
 		return err

--- a/resource_contentful_space_test.go
+++ b/resource_contentful_space_test.go
@@ -30,8 +30,7 @@ func TestAccContentfulSpace_Basic(t *testing.T) {
 }
 
 func testAccCheckContentfulSpaceDestroy(s *terraform.State) error {
-	configMap := testAccProvider.Meta().(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := testAccProvider.Meta().(*contentful.Contentful)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "contentful_space" {

--- a/resource_contentful_webhook.go
+++ b/resource_contentful_webhook.go
@@ -61,8 +61,7 @@ func resourceContentfulWebhook() *schema.Resource {
 }
 
 func resourceCreateWebhook(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -93,8 +92,7 @@ func resourceCreateWebhook(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceUpdateWebhook(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -129,8 +127,7 @@ func resourceUpdateWebhook(d *schema.ResourceData, m interface{}) (err error) {
 }
 
 func resourceReadWebhook(d *schema.ResourceData, m interface{}) error {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {
@@ -151,8 +148,7 @@ func resourceReadWebhook(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceDeleteWebhook(d *schema.ResourceData, m interface{}) (err error) {
-	configMap := m.(map[string]interface{})
-	client := configMap["client"].(*contentful.Contentful)
+	client := m.(*contentful.Contentful)
 
 	space, err := client.GetSpace(d.Get("space_id").(string))
 	if err != nil {

--- a/resource_contentful_webhook_test.go
+++ b/resource_contentful_webhook_test.go
@@ -61,9 +61,8 @@ func testAccCheckContentfulWebhookExists(n string, webhook *contentful.Webhook) 
 			return fmt.Errorf("No webhook ID is set")
 		}
 
-		// read config map and get sdk client
-		configMap := testAccProvider.Meta().(map[string]interface{})
-		client := configMap["client"].(*contentful.Contentful)
+		// sdk client
+		client := testAccProvider.Meta().(*contentful.Contentful)
 
 		space, err := client.GetSpace(spaceID)
 		if err != nil {
@@ -123,9 +122,8 @@ func testAccContentfulWebhookDestroy(s *terraform.State) error {
 			return fmt.Errorf("No webhook ID is set")
 		}
 
-		// read config map and get sdk client
-		configMap := testAccProvider.Meta().(map[string]interface{})
-		client := configMap["client"].(*contentful.Contentful)
+		// sdk client
+		client := testAccProvider.Meta().(*contentful.Contentful)
 
 		space, err := client.GetSpace(spaceID)
 		if _, ok := err.(contentful.NotFoundError); ok {


### PR DESCRIPTION
- `configuration:` instead of storing `map` data in provider config, only store sdk client.
- `fix:` content type test case `displayField` key should be `display_field'
- `configuration:` dont set `BaseURL` anymore, sdk client now uses only `contentful.com` domain.