### PR TITLE
Cache go get dependencies

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -2,8 +2,10 @@ FROM golang:1.8
 
 WORKDIR /go/src/github.com/danihodovic/contentful-terraform
 
-COPY . /go/src/github.com/danihodovic/contentful-terraform
+# http://stackoverflow.com/questions/39278756/cache-go-get-in-docker-build
+COPY ./install-dependencies.sh /go/src/github.com/danihodovic/contentful-terraform/
+RUN ./install-dependencies.sh
 
-RUN go get
+COPY . /go/src/github.com/danihodovic/contentful-terraform
 
 CMD go test -v

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Let's avoid rebuilding the dependencies each time a source file changes.
+# See: http://stackoverflow.com/questions/39278756/cache-go-get-in-docker-build
+go get github.com/hashicorp/terraform/terraform
+go get github.com/hashicorp/terraform/helper/resource
+go get github.com/hashicorp/terraform/helper/schema
+go get github.com/tolgaakyuz/contentful-go


### PR DESCRIPTION
Running 'go get' after copying the source files causes us to re-build
all dependencies on every source file change.
If we instead specify our dependencies in install-dependencies.sh we can
install and cache them before installing the source files. It's a ghetto
approach, but greatly improves build times between tests.